### PR TITLE
(TEMP SOLUTION) regex matches asset urls in ad box includes

### DIFF
--- a/lib/liquid-loader.js
+++ b/lib/liquid-loader.js
@@ -35,10 +35,11 @@ module.exports = function liquidLoader(content) {
   // Assume that quoted asset_* are not variables, but actual assets.
   // Match anything after `asset_`, until `}}`
   // ie.: will match asset_url, asset_image_url: '300px', ...
-  const regex = /{{ '(.*)' \| asset_([^}}]*)}}/g
+  const regex = /{%\s+include\s+'ad-box'.*image:.*'(..\/assets\/images\/.*)'.*%}|{{ '(.*)' \| asset_([^}}]*)}}/g
 
   // Replace each file with a unique key, to be converted to require() later.
-  const keyedContent = content.replace(regex, (liquidExpr, file) => {
+  const keyedContent = content.replace(regex, (liquidExpr, capture1, capture2) => {
+    const file = capture1 || capture2;
     const key = `__LIQUID_LOADER_${getUniqueKey()}__`
 
     // We're on a dev server, replace the whole liquid expression


### PR DESCRIPTION
There needs to be a better solution for adding commit hashes to asset paths stored in variables, but this works for getting us live and allowing people to keep working off of master.